### PR TITLE
fix: remove references to the old repo

### DIFF
--- a/examples/server/main.go
+++ b/examples/server/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/zknill/service"
+	"github.com/Attest/service"
 )
 
 func main() {

--- a/group_test.go
+++ b/group_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/zknill/service"
+	"github.com/Attest/service"
 )
 
 func TestGroup(t *testing.T) {

--- a/probes_test.go
+++ b/probes_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/zknill/service"
+	"github.com/Attest/service"
 )
 
 func TestProbes(t *testing.T) {


### PR DESCRIPTION
Removes the references to Zak's repo from examples and tests, so that Go doesn't pull the old repo into dependencies.